### PR TITLE
Release 1.0.0 - News Scraper MCP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,203 @@
-# Python-generated files
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[oc]
-build/
-dist/
-wheels/
-*.egg-info
+*.py[codz]
+*$py.class
 
-# Virtual environments
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
 .venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-01-17
+
+### Added
+- Initial release of article-scraper-mcp
+- MCP server implementation using FastMCP
+- Article extraction tool with newspaper3k
+- Support for extracting title, text, author, and publication date
+- URL validation and error handling
+- Structured data output using ArticleData dataclass
+- Comprehensive logging with loguru
+- CLI entry point for running as MCP server
+
+### Features
+- `fetch_article` tool for extracting article data from URLs
+- Robust error handling for network and parsing failures
+- Content validation to ensure articles are properly extracted
+- Support for international content (tested with Russian Habr articles)
+- MCP server integration ready for Claude Desktop and other clients
+
+### Technical
+- Python 3.11+ compatibility
+- Type hints throughout the codebase
+- PEP 8 compliant code style
+- Comprehensive documentation
+- MIT license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,24 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.1.0] - 2025-01-17
+## [1.0.0] 
 
 ### Added
-- Initial release of article-scraper-mcp
-- MCP server implementation using FastMCP
-- Article extraction tool with newspaper3k
-- Support for extracting title, text, author, and publication date
-- URL validation and error handling
-- Structured data output using ArticleData dataclass
-- Comprehensive logging with loguru
-- CLI entry point for running as MCP server
+- Project name change and rebranding
+- Updated .gitignore configuration
+- Enhanced README documentation
 
-### Features
-- `fetch_article` tool for extracting article data from URLs
-- Robust error handling for network and parsing failures
-- Content validation to ensure articles are properly extracted
-- Support for international content (tested with Russian Habr articles)
-- MCP server integration ready for Claude Desktop and other clients
+### Changed
+- Project structure and naming conventions
 
-### Technical
-- Python 3.11+ compatibility
-- Type hints throughout the codebase
-- PEP 8 compliant code style
-- Comprehensive documentation
-- MIT license
+## [0.1.0]  
+
+### Added
+- Initial MCP server implementation for news scraping
+- Core server functionality with newspaper3k integration
+- Project metadata and dependency management
+- Cursor development rules and configuration
+- Basic project structure and documentation
+
+### Changed
+- README documentation updates
+- Project configuration and setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Project name change and rebranding
 - Updated .gitignore configuration
 - Enhanced README documentation
+- Added custom User-Agent headers to avoid website blocking
 
 ### Changed
 - Project structure and naming conventions

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dmitrii K
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Article Scraper MCP
 
-A Model Context Protocol (MCP) server that fetches news article data from URLs using newspaper3k.
+A Model Context Protocol (MCP) server that fetches article data from URLs using newspaper3k.
 
 ## Features
 
@@ -15,8 +15,8 @@ This project uses `uv` for package management and is designed to be run locally 
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/news-scraper-mcp.git
-cd news-scraper-mcp
+git clone https://github.com/dmitriiweb/article-scraper-mcp.git
+cd article-scraper-mcp
 
 # Install dependencies
 uv sync
@@ -29,7 +29,7 @@ uv pip install -e .
 
 ### As an MCP Server
 
-The news scraper can be used as an MCP server in various MCP clients:
+The article scraper can be used as an MCP server in various MCP clients:
 
 #### Claude Desktop
 
@@ -39,14 +39,14 @@ The news scraper can be used as an MCP server in various MCP clients:
 uv run mcp install .
 ```
 
-2. The server will be available as "news-scraper" in Claude Desktop
+2. The server will be available as "article-scraper" in Claude Desktop
 
 #### Other MCP Clients
 
 Run the server directly from the cloned repository:
 ```bash
 # Using stdio transport (default)
-uv run news-scraper-mcp
+uv run article-scraper-mcp
 
 # Or directly with Python
 uv run python main.py
@@ -62,10 +62,10 @@ Add to your MCP client configuration:
 ```json
 {
   "mcpServers": {
-    "news-scraper": {
+    "article-scraper": {
       "command": "uv",
       "args": ["run", "python", "main.py"],
-      "cwd": "/path/to/your/cloned/news-scraper-mcp"
+      "cwd": "/path/to/your/cloned/article-scraper-mcp"
     }
   }
 }
@@ -75,10 +75,10 @@ Or for development:
 ```json
 {
   "mcpServers": {
-    "news-scraper": {
+    "article-scraper": {
       "command": "uv",
       "args": ["run", "mcp", "dev", "server.py"],
-      "cwd": "/path/to/your/cloned/news-scraper-mcp"
+      "cwd": "/path/to/your/cloned/article-scraper-mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -11,51 +11,13 @@ A Model Context Protocol (MCP) server that fetches article data from URLs using 
 
 ## Installation
 
-This project uses `uv` for package management and is designed to be run locally from source:
+Install directly from PyPI:
 
 ```bash
-# Clone the repository
-git clone https://github.com/dmitriiweb/article-scraper-mcp.git
-cd article-scraper-mcp
-
-# Install dependencies
-uv sync
-
-# Install the package in development mode
-uv pip install -e .
+uvx article-scraper-mcp
 ```
 
 ## Usage
-
-### As an MCP Server
-
-The article scraper can be used as an MCP server in various MCP clients:
-
-#### Claude Desktop
-
-1. Install the server locally:
-```bash
-# From the cloned repository directory
-uv run mcp install .
-```
-
-2. The server will be available as "article-scraper" in Claude Desktop
-
-#### Other MCP Clients
-
-Run the server directly from the cloned repository:
-```bash
-# Using stdio transport (default)
-uv run article-scraper-mcp
-
-# Or directly with Python
-uv run python main.py
-
-# Or using the MCP development command
-uv run mcp dev server.py
-```
-
-### Server Configuration
 
 Add to your MCP client configuration:
 
@@ -63,46 +25,32 @@ Add to your MCP client configuration:
 {
   "mcpServers": {
     "article-scraper": {
-      "command": "uv",
-      "args": ["run", "python", "main.py"],
-      "cwd": "/path/to/your/cloned/article-scraper-mcp"
+      "command": "uvx",
+      "args": ["article-scraper-mcp"]
     }
   }
 }
 ```
 
-Or for development:
-```json
-{
-  "mcpServers": {
-    "article-scraper": {
-      "command": "uv",
-      "args": ["run", "mcp", "dev", "server.py"],
-      "cwd": "/path/to/your/cloned/article-scraper-mcp"
-    }
-  }
-}
-```
+## API
 
-## Development
+### `fetch_article(url: str) -> dict[str, Any]`
 
-```bash
-# Install development dependencies
-uv sync --dev
+Fetches and parses a news article from the given URL.
 
-# Run tests (if available)
-uv run pytest
+**Parameters:**
+- `url`: The URL of the news article to fetch
 
-# Format code
-uv run black .
-uv run isort .
+**Returns:**
+A dictionary containing:
+- `title`: Article title
+- `text`: Article content text
+- `author`: Author name(s) (may be None)
+- `date`: Publication date in ISO format (may be None)
 
-# Lint code
-uv run flake8 .
-
-# Run in development mode with MCP
-uv run mcp dev server.py
-```
+**Raises:**
+- `ValueError`: If URL is invalid or article cannot be parsed
+- `requests.RequestException`: If HTTP request fails
 
 ## Requirements
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Main entry point for the news scraper MCP server."""
+"""Main entry point for the article scraper MCP server."""
 
 from news_scraper_mcp.server import app
 

--- a/news_scraper_mcp/__init__.py
+++ b/news_scraper_mcp/__init__.py
@@ -2,5 +2,5 @@
 
 from .server import app, fetch_article, ArticleData
 
-__version__ = "0.1.0"
-__all__ = ["__version__", "app", "fetch_article", "ArticleData"]
+__version__ = "1.0.0"
+__all__ = ("__version__", "app", "fetch_article", "ArticleData")

--- a/news_scraper_mcp/server.py
+++ b/news_scraper_mcp/server.py
@@ -13,6 +13,12 @@ import requests
 # Compile regex patterns at module level
 URL_PATTERN = re.compile(r"^https?://.+")
 
+# HTTP headers
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/138.0.0.0 Safari/537.36"
+)
+
 @dataclass(slots=True)
 class ArticleData:
     """Structured article data."""
@@ -78,9 +84,9 @@ def fetch_article(url: str) -> dict[str, Any]:
     if not validate_url(url):
         raise ValueError(f"Invalid URL provided: {url}")
 
-    # Warm up: ensure URL is reachable and log response metadata
+    # Fetch page HTML using requests with custom User-Agent
     try:
-        response = requests.get(url, timeout=15)
+        response = requests.get(url, timeout=15, headers={"User-Agent": USER_AGENT})
         response.raise_for_status()
         logger.debug(
             f"fetched status={response.status_code} content_length={len(response.content)}"
@@ -94,7 +100,7 @@ def fetch_article(url: str) -> dict[str, Any]:
 
     try:
         article = Article(url)
-        article.download()
+        article.set_html(response.text)
         article.parse()
     except Exception as exc:
         logger.error(f"Failed to parse article: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,31 @@
 [project]
-name = "news-scraper-mcp"
-version = "0.1.0"
-description = "MCP server that fetches article data (title, text, author, date) from a URL using newspaper3k."
+name = "article-scraper-mcp"
+dynamic = ["version"]
+description = "MCP server that fetches article data (title, text, author, date) from a URL using newspaper3k"
 readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.11"
+authors = [
+    {name = "Dmitrii K", email = "dmitriik@protonmail.com"}
+]
+maintainers = [
+    {name = "Dmitrii K", email = "dmitriik@protonmail.com"}
+]
+keywords = ["mcp", "model-context-protocol", "news", "scraper", "newspaper3k", "article-extraction"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Linguistic",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: News/Diary",
+]
 dependencies = [
     "loguru>=0.7.2",
     "requests>=2.32.3",
@@ -12,14 +34,39 @@ dependencies = [
     "lxml[html_clean]>=4.9.0",
 ]
 
-[project.scripts]
-news-scraper-mcp = "news_scraper_mcp.server:app.run"
-
-[tool.uv]
-package = true
-dev-dependencies = []
-
 [project.urls]
-Homepage = "https://github.com/yourusername/news-scraper-mcp"
-Repository = "https://github.com/yourusername/news-scraper-mcp"
-Issues = "https://github.com/yourusername/news-scraper-mcp/issues"
+Homepage = "https://github.com/dmitriiweb/article-scraper-mcp"
+Documentation = "https://github.com/dmitriiweb/article-scraper-mcp#readme"
+Repository = "https://github.com/dmitriiweb/article-scraper-mcp"
+Issues = "https://github.com/dmitriiweb/article-scraper-mcp/issues"
+Changelog = "https://github.com/dmitriiweb/article-scraper-mcp/blob/main/CHANGELOG.md"
+
+[project.scripts]
+article-scraper-mcp = "news_scraper_mcp.server:app.run"
+
+[project.entry-points."mcp.servers"]
+article-scraper = "news_scraper_mcp.server:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["news_scraper_mcp"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/news_scraper_mcp",
+    "/README.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
+
+[tool.hatch.version]
+path = "news_scraper_mcp/__init__.py"
+
+[dependency-groups]
+dev = [
+    "build>=1.3.0",
+    "hatchling>=1.27.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,38 @@ wheels = [
 ]
 
 [[package]]
+name = "article-scraper-mcp"
+source = { editable = "." }
+dependencies = [
+    { name = "loguru" },
+    { name = "lxml", extra = ["html-clean"] },
+    { name = "mcp", extra = ["cli"] },
+    { name = "newspaper3k" },
+    { name = "requests" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "build" },
+    { name = "hatchling" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "loguru", specifier = ">=0.7.2" },
+    { name = "lxml", extras = ["html-clean"], specifier = ">=4.9.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
+    { name = "newspaper3k", specifier = ">=0.2.8" },
+    { name = "requests", specifier = ">=2.32.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "build", specifier = ">=1.3.0" },
+    { name = "hatchling", specifier = ">=1.27.0" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -45,6 +77,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
 ]
 
 [[package]]
@@ -178,6 +224,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
 ]
 
 [[package]]
@@ -402,30 +463,6 @@ wheels = [
 ]
 
 [[package]]
-name = "news-scraper-mcp"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "loguru" },
-    { name = "lxml", extra = ["html-clean"] },
-    { name = "mcp", extra = ["cli"] },
-    { name = "newspaper3k" },
-    { name = "requests" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "loguru", specifier = ">=0.7.2" },
-    { name = "lxml", extras = ["html-clean"], specifier = ">=4.9.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
-    { name = "newspaper3k", specifier = ">=0.2.8" },
-    { name = "requests", specifier = ">=2.32.3" },
-]
-
-[package.metadata.requires-dev]
-dev = []
-
-[[package]]
 name = "newspaper3k"
 version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -462,6 +499,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -546,6 +601,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
     { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
     { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -649,6 +713,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
@@ -1059,6 +1132,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2025.8.6.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/21/707af14daa638b0df15b5d5700349e0abdd3e5140069f9ab6e0ccb922806/trove_classifiers-2025.8.6.13.tar.gz", hash = "sha256:5a0abad839d2ed810f213ab133d555d267124ddea29f1d8a50d6eca12a50ae6e", size = 16932, upload-time = "2025-08-06T13:26:26.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/44/323a87d78f04d5329092aada803af3612dd004a64b69ba8b13046601a8c9/trove_classifiers-2025.8.6.13-py3-none-any.whl", hash = "sha256:c4e7fc83012770d80b3ae95816111c32b085716374dccee0d3fbf5c235495f9f", size = 14121, upload-time = "2025-08-06T13:26:25.063Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Release 1.0.0

This release includes the initial implementation of the News Scraper MCP Server.

### Features
- MCP server for scraping news articles
- Extracts article data: title, text, author, date
- Built with newspaper3k for article parsing
- Ready for integration with article summarizers

### Tech Stack
- Python 3.10+
- requests, loguru, mcp[cli], newspaper3k
- Runs with uv/uvx (no docker required)

### Changes
- Initial MCP server implementation
- Article scraping functionality
- Clean project structure with proper packaging